### PR TITLE
TypeChartのリファクタリング: 命名改善・スコープ適正化・フォーマット統一

### DIFF
--- a/src/PokemonTools.ApiService.Domain/Types/TypeChart.cs
+++ b/src/PokemonTools.ApiService.Domain/Types/TypeChart.cs
@@ -20,36 +20,42 @@ public static class TypeChart
     /// <summary>
     /// 攻撃タイプと防御タイプ1〜2つから最終的な相性を返す
     /// </summary>
-    public static TypeEffectiveness GetEffectiveness(
-        PokemonType attackType, PokemonType defenseType1, PokemonType? defenseType2 = null)
+    public static TypeEffectiveness GetEffectiveness(PokemonType attackType, PokemonType defenseType1, PokemonType? defenseType2 = null)
     {
-        if (defenseType2 is null)
+        if (defenseType2 is not null)
+        {
+            var effectiveness1 = GetEffectiveness(attackType, defenseType1);
+            var effectiveness2 = GetEffectiveness(attackType, defenseType2);
+            return Combine(effectiveness1, effectiveness2);
+        }
+        else
         {
             return GetEffectiveness(attackType, defenseType1);
         }
 
-        var e1 = GetEffectiveness(attackType, defenseType1);
-        var e2 = GetEffectiveness(attackType, defenseType2);
-        return Combine(e1, e2);
-    }
-
-    private static TypeEffectiveness Combine(TypeEffectiveness e1, TypeEffectiveness e2)
-    {
-        return (e1, e2) switch
+        static TypeEffectiveness Combine(TypeEffectiveness effectiveness1, TypeEffectiveness effectiveness2)
         {
-            _ when e1 == TypeEffectiveness.HasNoEffect || e2 == TypeEffectiveness.HasNoEffect
-                => TypeEffectiveness.HasNoEffect,
-            (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.MostlyIneffective,
-            (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.Neutral) or
-            (TypeEffectiveness.Neutral, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.NotVeryEffective,
-            (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.SuperEffective) or
-            (TypeEffectiveness.SuperEffective, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.Neutral,
-            (TypeEffectiveness.Neutral, TypeEffectiveness.Neutral) => TypeEffectiveness.Neutral,
-            (TypeEffectiveness.Neutral, TypeEffectiveness.SuperEffective) or
-            (TypeEffectiveness.SuperEffective, TypeEffectiveness.Neutral) => TypeEffectiveness.SuperEffective,
-            (TypeEffectiveness.SuperEffective, TypeEffectiveness.SuperEffective) => TypeEffectiveness.ExtremelyEffective,
-            _ => throw new InvalidOperationException($"予期しないタイプ相性の組み合わせです: {e1}, {e2}"),
-        };
+            return (effectiveness1, effectiveness2) switch
+            {
+                (TypeEffectiveness.HasNoEffect, TypeEffectiveness.HasNoEffect) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.HasNoEffect, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.HasNoEffect, TypeEffectiveness.Neutral) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.HasNoEffect, TypeEffectiveness.SuperEffective) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.HasNoEffect) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.MostlyIneffective,
+                (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.Neutral) => TypeEffectiveness.NotVeryEffective,
+                (TypeEffectiveness.NotVeryEffective, TypeEffectiveness.SuperEffective) => TypeEffectiveness.Neutral,
+                (TypeEffectiveness.Neutral, TypeEffectiveness.HasNoEffect) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.Neutral, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.NotVeryEffective,
+                (TypeEffectiveness.Neutral, TypeEffectiveness.Neutral) => TypeEffectiveness.Neutral,
+                (TypeEffectiveness.Neutral, TypeEffectiveness.SuperEffective) => TypeEffectiveness.SuperEffective,
+                (TypeEffectiveness.SuperEffective, TypeEffectiveness.HasNoEffect) => TypeEffectiveness.HasNoEffect,
+                (TypeEffectiveness.SuperEffective, TypeEffectiveness.NotVeryEffective) => TypeEffectiveness.Neutral,
+                (TypeEffectiveness.SuperEffective, TypeEffectiveness.Neutral) => TypeEffectiveness.SuperEffective,
+                (TypeEffectiveness.SuperEffective, TypeEffectiveness.SuperEffective) => TypeEffectiveness.ExtremelyEffective,
+                _ => throw new InvalidOperationException($"予期しないタイプ相性の組み合わせです: {effectiveness1}, {effectiveness2}"),
+            };
+        }
     }
 
     private static FrozenDictionary<(TypeId, TypeId), TypeEffectiveness> BuildChart()
@@ -57,122 +63,177 @@ public static class TypeChart
         var dict = new Dictionary<(TypeId, TypeId), TypeEffectiveness>();
 
         // ノーマル
-        Set(dict, PokemonType.Normal,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Normal,
             superEffective: [],
             notVeryEffective: [PokemonType.Rock, PokemonType.Steel],
-            noEffect: [PokemonType.Ghost]);
+            noEffect: [PokemonType.Ghost]
+        );
 
         // かくとう
-        Set(dict, PokemonType.Fighting,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Fighting,
             superEffective: [PokemonType.Normal, PokemonType.Rock, PokemonType.Steel, PokemonType.Ice, PokemonType.Dark],
             notVeryEffective: [PokemonType.Flying, PokemonType.Poison, PokemonType.Bug, PokemonType.Psychic, PokemonType.Fairy],
-            noEffect: [PokemonType.Ghost]);
+            noEffect: [PokemonType.Ghost]
+        );
 
         // ひこう
-        Set(dict, PokemonType.Flying,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Flying,
             superEffective: [PokemonType.Fighting, PokemonType.Bug, PokemonType.Grass],
             notVeryEffective: [PokemonType.Rock, PokemonType.Steel, PokemonType.Electric],
-            noEffect: []);
+            noEffect: []
+        );
 
         // どく
-        Set(dict, PokemonType.Poison,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Poison,
             superEffective: [PokemonType.Grass, PokemonType.Fairy],
             notVeryEffective: [PokemonType.Poison, PokemonType.Ground, PokemonType.Rock, PokemonType.Ghost],
-            noEffect: [PokemonType.Steel]);
+            noEffect: [PokemonType.Steel]
+        );
 
         // じめん
-        Set(dict, PokemonType.Ground,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Ground,
             superEffective: [PokemonType.Poison, PokemonType.Rock, PokemonType.Steel, PokemonType.Fire, PokemonType.Electric],
             notVeryEffective: [PokemonType.Bug, PokemonType.Grass],
-            noEffect: [PokemonType.Flying]);
+            noEffect: [PokemonType.Flying]
+        );
 
         // いわ
-        Set(dict, PokemonType.Rock,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Rock,
             superEffective: [PokemonType.Flying, PokemonType.Bug, PokemonType.Fire, PokemonType.Ice],
             notVeryEffective: [PokemonType.Fighting, PokemonType.Ground, PokemonType.Steel],
-            noEffect: []);
+            noEffect: []
+        );
 
         // むし
-        Set(dict, PokemonType.Bug,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Bug,
             superEffective: [PokemonType.Grass, PokemonType.Psychic, PokemonType.Dark],
             notVeryEffective: [PokemonType.Fighting, PokemonType.Flying, PokemonType.Poison, PokemonType.Ghost, PokemonType.Steel, PokemonType.Fire, PokemonType.Fairy],
-            noEffect: []);
+            noEffect: []
+        );
 
         // ゴースト
-        Set(dict, PokemonType.Ghost,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Ghost,
             superEffective: [PokemonType.Ghost, PokemonType.Psychic],
             notVeryEffective: [PokemonType.Dark],
-            noEffect: [PokemonType.Normal]);
+            noEffect: [PokemonType.Normal]
+        );
 
         // はがね
-        Set(dict, PokemonType.Steel,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Steel,
             superEffective: [PokemonType.Rock, PokemonType.Ice, PokemonType.Fairy],
             notVeryEffective: [PokemonType.Steel, PokemonType.Fire, PokemonType.Water, PokemonType.Electric],
-            noEffect: []);
+            noEffect: []
+        );
 
         // ほのお
-        Set(dict, PokemonType.Fire,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Fire,
             superEffective: [PokemonType.Bug, PokemonType.Steel, PokemonType.Grass, PokemonType.Ice],
             notVeryEffective: [PokemonType.Rock, PokemonType.Fire, PokemonType.Water, PokemonType.Dragon],
-            noEffect: []);
+            noEffect: []
+        );
 
         // みず
-        Set(dict, PokemonType.Water,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Water,
             superEffective: [PokemonType.Ground, PokemonType.Rock, PokemonType.Fire],
             notVeryEffective: [PokemonType.Water, PokemonType.Grass, PokemonType.Dragon],
-            noEffect: []);
+            noEffect: []
+        );
 
         // くさ
-        Set(dict, PokemonType.Grass,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Grass,
             superEffective: [PokemonType.Ground, PokemonType.Rock, PokemonType.Water],
             notVeryEffective: [PokemonType.Flying, PokemonType.Poison, PokemonType.Bug, PokemonType.Steel, PokemonType.Fire, PokemonType.Grass, PokemonType.Dragon],
-            noEffect: []);
+            noEffect: []
+        );
 
         // でんき
-        Set(dict, PokemonType.Electric,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Electric,
             superEffective: [PokemonType.Flying, PokemonType.Water],
             notVeryEffective: [PokemonType.Grass, PokemonType.Electric, PokemonType.Dragon],
-            noEffect: [PokemonType.Ground]);
+            noEffect: [PokemonType.Ground]
+        );
 
         // エスパー
-        Set(dict, PokemonType.Psychic,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Psychic,
             superEffective: [PokemonType.Fighting, PokemonType.Poison],
             notVeryEffective: [PokemonType.Steel, PokemonType.Psychic],
-            noEffect: [PokemonType.Dark]);
+            noEffect: [PokemonType.Dark]
+        );
 
         // こおり
-        Set(dict, PokemonType.Ice,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Ice,
             superEffective: [PokemonType.Flying, PokemonType.Ground, PokemonType.Grass, PokemonType.Dragon],
             notVeryEffective: [PokemonType.Steel, PokemonType.Fire, PokemonType.Water, PokemonType.Ice],
-            noEffect: []);
+            noEffect: []
+        );
 
         // ドラゴン
-        Set(dict, PokemonType.Dragon,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Dragon,
             superEffective: [PokemonType.Dragon],
             notVeryEffective: [PokemonType.Steel],
-            noEffect: [PokemonType.Fairy]);
+            noEffect: [PokemonType.Fairy]
+        );
 
         // あく
-        Set(dict, PokemonType.Dark,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Dark,
             superEffective: [PokemonType.Ghost, PokemonType.Psychic],
             notVeryEffective: [PokemonType.Fighting, PokemonType.Dark, PokemonType.Fairy],
-            noEffect: []);
+            noEffect: []
+        );
 
         // フェアリー
-        Set(dict, PokemonType.Fairy,
+        SetTypeEffectiveness(
+            dict,
+            PokemonType.Fairy,
             superEffective: [PokemonType.Fighting, PokemonType.Dragon, PokemonType.Dark],
             notVeryEffective: [PokemonType.Poison, PokemonType.Steel, PokemonType.Fire],
-            noEffect: []);
+            noEffect: []
+        );
 
         return dict.ToFrozenDictionary();
     }
 
-    private static void Set(
+    private static void SetTypeEffectiveness(
         Dictionary<(TypeId, TypeId), TypeEffectiveness> dict,
         PokemonType attackType,
         PokemonType[] superEffective,
         PokemonType[] notVeryEffective,
-        PokemonType[] noEffect)
+        PokemonType[] noEffect
+    )
     {
         foreach (var def in superEffective)
         {


### PR DESCRIPTION
## Summary
- `Combine` メソッドを `private static` から `GetEffectiveness` 内のローカル関数に変更（スコープ適正化）
- 変数名 `e1`/`e2` → `effectiveness1`/`effectiveness2`、メソッド名 `Set` → `SetTypeEffectiveness` に改善
- switch式のワイルドカード/`or` パターンを全パターン明示列挙に変更（enum順序依存の排除）
- 引数の縦並びフォーマットに統一

## Test plan
- [x] 全 363 テスト パス確認済み（失敗: 0、スキップ: 0）
- [ ] CI での自動テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)