### PR TITLE
テストクラス・メソッドの命名規則をガイドラインに準拠

### DIFF
--- a/tests/PokemonTools.ApiService.Domain.Tests/Types/TypeChart_GetEffectivenessTests.cs
+++ b/tests/PokemonTools.ApiService.Domain.Tests/Types/TypeChart_GetEffectivenessTests.cs
@@ -76,7 +76,7 @@ public class TypeChart_GetEffectivenessTests
 
     [Theory]
     [MemberData(nameof(複合タイプ相性データ))]
-    public void 複合タイプ相性を確認する_正しい結果が返る(string attackTypeId, string defenseType1Id, string defenseType2Id, TypeEffectiveness expected)
+    public void 複合タイプ相性の確認_正しい結果が返る(string attackTypeId, string defenseType1Id, string defenseType2Id, TypeEffectiveness expected)
     {
         // Arrange
         var attackType = FindType(attackTypeId);
@@ -142,7 +142,7 @@ public class TypeChart_GetEffectivenessTests
     #region 複合タイプ動作テスト
 
     [Fact]
-    public void 防御タイプ2がnullの場合は単タイプとして計算()
+    public void 防御タイプ2がnull_単タイプとして計算()
     {
         // Act
         var result = TypeChart.GetEffectiveness(PokemonType.Fire, PokemonType.Grass, null);
@@ -153,7 +153,7 @@ public class TypeChart_GetEffectivenessTests
 
     [Theory]
     [MemberData(nameof(防御タイプ順序テストデータ))]
-    public void 防御タイプの順序が結果に影響しない(
+    public void 防御タイプの順序の入れ替え_結果に影響しない(
         string attackTypeId, string defenseType1Id, string defenseType2Id)
     {
         // Arrange


### PR DESCRIPTION
## Summary
- `TypeChartTests` → `TypeChart_GetEffectivenessTests` にリネーム（「対象クラス_対象メソッド」形式に準拠）
- テストメソッド名を「条件_期待される挙動や出力」パターンに変更
- `FindType` ヘルパーメソッドをクラス末尾に移動

## Test plan
- [x] `dotnet test` で全363テストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)